### PR TITLE
Systemd service file, config file and installer.  (Issue18,issue3)

### DIFF
--- a/service/engMQTTClient_service.sh
+++ b/service/engMQTTClient_service.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script to launch the energenie MQTT client
+# Normally this script will be stored in /usr/bin/engMQTTClient_service.sh
+
+source /etc/engmqttclient.conf
+
+sleep 10s 
+LD_LIBRARY_PATH=/usr/local/lib ${ENGMQTT_BIN} -h ${ENGMQTT_SERVER} -u ${ENGMQTT_USER} -P ${ENGMQTT_PASS}
+echo "engmqtt completed with exit code $?"

--- a/service/engmqttclient.conf
+++ b/service/engmqttclient.conf
@@ -1,0 +1,16 @@
+# Energenie MQTT client configuration file
+# Normally this is stored in /etc/engmqttclient.conf
+
+# The location of the engMQTTclient binary.  Change this if you are directly using
+# e.g. a git checkout of the repository
+ENGMQTT_BIN=/home/pi/engMQTTClient_dev2/engMQTTClient/engMQTTClient
+
+# The hostname or IP address of the MQTT broker.  
+# Set to localhost if the broker is running on the same machine.
+ENGMQTT_SERVER=localhost
+
+# Username for connecting to MQTT broker.  (set to "" if unused)
+ENGMQTT_USER=""
+
+# Password for connecting to MQTT broker.  (set to "" if unused)
+ENGMQTT_PASS=""

--- a/service/engmqttclient.conf
+++ b/service/engmqttclient.conf
@@ -3,7 +3,7 @@
 
 # The location of the engMQTTclient binary.  Change this if you are directly using
 # e.g. a git checkout of the repository
-ENGMQTT_BIN=/home/pi/engMQTTClient_dev2/engMQTTClient/engMQTTClient
+ENGMQTT_BIN=/usr/bin/engMQTTClient
 
 # The hostname or IP address of the MQTT broker.  
 # Set to localhost if the broker is running on the same machine.

--- a/service/engmqttclient.service
+++ b/service/engmqttclient.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Energenie MQTT systemd service.
+Wants=network-online.target
+After=network-online.target
+#Wants=mosquitto.service
+#After=mosquitto.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/engMQTTClient_service.sh
+Restart=on-failure
+RestartSec=60s
+
+[Install]
+WantedBy=multi-user.target

--- a/service/install.sh
+++ b/service/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Set up engmqttclient as a systemd service
+
+echo "Copying files..."
+cp -i engmqttclient.conf /etc/engmqttclient.conf 
+cp -i engMQTTClient_service.sh /usr/bin/engMQTTClient_service.sh
+cp -i engmqttclient.service /etc/systemd/system/engmqttclient.service
+echo "Calling systemctl daemon-reload..."
+systemctl daemon-reload
+
+echo "Installation complete"
+echo ""
+echo "Now edit /etc/engmqttclient.conf to update with your local configuration."
+echo ""
+echo "To test the service use:"
+echo "sudo systemctl start engmqttclient.service"
+echo "To permanently enable the service use:"
+echo "sudo systemctl enable engmqttclient.service"

--- a/service/install.sh
+++ b/service/install.sh
@@ -3,9 +3,15 @@
 # Set up engmqttclient as a systemd service
 
 echo "Copying files..."
+cp -i ../engMQTTClient /usr/bin/
+chown root:root /usr/bin/engMQTTClient
 cp -i engmqttclient.conf /etc/engmqttclient.conf 
+chown root:root /etc/engmqttclient.conf
 cp -i engMQTTClient_service.sh /usr/bin/engMQTTClient_service.sh
+chown root:root /usr/bin/engMQTTClient_service.sh
 cp -i engmqttclient.service /etc/systemd/system/engmqttclient.service
+chown root:root /etc/systemd/system/engmqttclient.service
+
 echo "Calling systemctl daemon-reload..."
 systemctl daemon-reload
 


### PR DESCRIPTION
This PR provides example systemd service files and a configuration file.

To use it, run
```
cd service
sudo ./install.sh
```
Then edit /etc/engmqttclient.conf with relevant config details (broker host, username, password etc)

Fixes #3,#18